### PR TITLE
Cambio retorno getItem iOS

### DIFF
--- a/src/ios/SecureStorage.m
+++ b/src/ios/SecureStorage.m
@@ -24,7 +24,8 @@
     if ([query fetch:&error]) {
         [self successWithMessage: query.password];
     } else {
-        [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
+        [self successWithMessage: nil];
+        // [self failWithMessage: @"Failure in SecureStorage.get()" withError: error];
     }
 }
 


### PR DESCRIPTION
En caso que no se encuentre el item en el Secure Storage, entonces retorna nulo en vez de fallar (o ejecutar evento catch).
